### PR TITLE
move TaskRoleArn out of ContainerDefinitions

### DIFF
--- a/workshop3/hints/final-service.yml
+++ b/workshop3/hints/final-service.yml
@@ -70,6 +70,7 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     Properties:
       Family: iridium
+      TaskRoleArn: !Ref ECSTaskRole
       ContainerDefinitions:
         - Name: iridium
           Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${Repository}:${Tag}
@@ -80,7 +81,6 @@ Resources:
           Environment:
             - Name: Tag
               Value: !Ref Tag
-          TaskRoleArn: !Ref ECSTaskRole
           LogConfiguration:
               LogDriver: awslogs
               Options:

--- a/workshop3/hints/new-service.yml
+++ b/workshop3/hints/new-service.yml
@@ -64,6 +64,7 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     Properties:
       Family: iridium
+      TaskRoleArn: !Ref ECSTaskRole
       ContainerDefinitions:
         - Name: iridium
           Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${Repository}:${Tag}
@@ -74,7 +75,6 @@ Resources:
           Environment:
             - Name: Tag
               Value: !Ref Tag
-          TaskRoleArn: !Ref ECSTaskRole
           LogConfiguration:
               LogDriver: awslogs
               Options:

--- a/workshop3/index.html
+++ b/workshop3/index.html
@@ -944,6 +944,7 @@ TaskDefinition:
   Type: AWS::ECS::TaskDefinition
   Properties:
     Family: iridium
+    <b>TaskRoleArn: !Ref ECSTaskRole </b>
     ContainerDefinitions:
       - Name: iridium
         Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${Repository}:${Tag}
@@ -954,7 +955,6 @@ TaskDefinition:
         Environment:
           - Name: Tag
             Value: !Ref Tag
-        <b>TaskRoleArn: !Ref ECSTaskRole </b>
         LogConfiguration:
             LogDriver: awslogs
             Options:

--- a/workshop3/readme.md
+++ b/workshop3/readme.md
@@ -934,6 +934,7 @@ TaskDefinition:
   Type: AWS::ECS::TaskDefinition
   Properties:
     Family: iridium
+    <b>TaskRoleArn: !Ref ECSTaskRole </b>
     ContainerDefinitions:
       - Name: iridium
         Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${Repository}:${Tag}
@@ -944,7 +945,6 @@ TaskDefinition:
         Environment:
           - Name: Tag
             Value: !Ref Tag
-        <b>TaskRoleArn: !Ref ECSTaskRole </b>
         LogConfiguration:
             LogDriver: awslogs
             Options:


### PR DESCRIPTION
#2 

Moved the TaskRoleArn up one or two levels within the yml TaskDefinition resource definition.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
